### PR TITLE
Add breadcrumbs to post detail page

### DIFF
--- a/src/components/BlogPost/BlogPost.tsx
+++ b/src/components/BlogPost/BlogPost.tsx
@@ -4,6 +4,7 @@ import { Query } from "react-apollo";
 import { RouteComponentProps, withRouter } from "react-router";
 import { IPost } from "../../models";
 import styled from "../../styled-components";
+import { Breadcrumb, Breadcrumbs } from "../Breadcrumbs";
 import Loader from "../Loader";
 import PageHeading from "../PageHeading";
 import Prose from "../Prose";
@@ -63,21 +64,37 @@ interface IProps extends RouteComponentProps<IPathProps> {}
 const BlogPost: React.FunctionComponent<IProps> = ({ match }) => (
   <Query query={POST_QUERY} variables={{ slug: match.params.postSlug }}>
     {({ loading, error, data }) => {
+      let content;
+      let post: IPost | null = null;
       if (loading) {
-        return <Loader />;
+        content = <Loader />;
+      } else if (error) {
+        content = <PageHeading>Could Not Load Post</PageHeading>;
+      } else {
+        post = data.post as IPost;
+        content = (
+          <React.Fragment>
+            <PageHeading>{post.title}</PageHeading>
+            <PostInfo post={post} />
+            <Prose dangerouslySetInnerHTML={{ __html: post.rendered }} />
+          </React.Fragment>
+        );
       }
 
-      if (error) {
-        return <PageHeading>Could Not Load Post</PageHeading>;
-      }
-
-      const post = data.post;
+      const breadcrumbs = (
+        <Breadcrumbs>
+          <Breadcrumb path="/blog">Blog</Breadcrumb>
+          <Breadcrumb active={true}>
+            {post ? post.title : match.params.postSlug}
+          </Breadcrumb>
+        </Breadcrumbs>
+      );
 
       return (
         <React.Fragment>
-          <PageHeading>{post.title}</PageHeading>
-          <PostInfo post={post} />
-          <Prose dangerouslySetInnerHTML={{ __html: post.rendered }} />
+          {breadcrumbs}
+          {content}
+          {breadcrumbs}
         </React.Fragment>
       );
     }}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+import styled from "../../styled-components";
+
+const BreadcrumbContainer = styled.div`
+  font-size: 1.25rem;
+  margin: 2rem 0;
+`;
+
+const HomeIcon = styled.i`
+  color: ${props => props.theme.colors.accent};
+`;
+
+const SeparatorIcon = styled.i.attrs({
+  className: "fas fa-chevron-right"
+})`
+  color: ${props => props.theme.colors.textMuted};
+  font-size: 1rem;
+  margin: 0.125rem 1em;
+`;
+
+const Link = styled(RouterLink)`
+  &,
+  &:visited {
+    color: ${props => props.theme.colors.accent};
+    text-decoration: none;
+  }
+`;
+
+type Breadcrumb = {
+  /** A standard breadcrumb is not active. */
+  active?: undefined | false;
+  /** The node to render as the breadcrumb link. */
+  children: React.ReactNode;
+  /** The path that the breadcrumb links to. */
+  path: string;
+};
+
+type BreadcrumbActive = {
+  /** An active breadcrumb, by definition, is active. */
+  active: true;
+  /**
+   * The node to render describing the current breadcrumb, typically a page
+   * title.
+   */
+  children: React.ReactNode;
+};
+
+/**
+ * Either an active or inactive breadcrumb can be passed to the component.
+ */
+type BreadcrumbProps = Breadcrumb | BreadcrumbActive;
+
+/**
+ * An individual breadcrumb.
+ *
+ * If the breadcrumb is not active, it is rendered as a link to the page it
+ * refers to. Otherwise it is displayed as plain text.
+ *
+ * @param props - The properties to render the breadcrumb with.
+ * @constructor
+ */
+const Breadcrumb: React.FunctionComponent<BreadcrumbProps> = props => {
+  if (props.active) {
+    return <span>{props.children}</span>;
+  }
+
+  return <Link to={props.path}>{props.children}</Link>;
+};
+
+interface IBreadcrumbsProps {
+  /** The breadcrumbs to render. */
+  children?:
+    | React.ReactElement<BreadcrumbProps>
+    | React.ReactElement<BreadcrumbProps>[];
+}
+
+/**
+ * Breadcrumbs to display where the user is in terms of the hierarchy of the
+ * site.
+ *
+ * @constructor
+ */
+const Breadcrumbs: React.FunctionComponent<IBreadcrumbsProps> = ({
+  children
+}) => {
+  console.log(children);
+  const childElements = [];
+
+  if (Array.isArray(children)) {
+    children.forEach((child, index) => {
+      childElements.push(
+        <React.Fragment
+          // As described in the following issue, Typescript doesn't allow us to
+          // specify the type of JSX we want to receive. This also means that we
+          // can't restrict the component to only allowing <Breadcrumb />
+          // components as children.
+          //
+          // https://stackoverflow.com/questions/52732021/react-component-children-typecheck-with-typescript
+          // https://github.com/Microsoft/TypeScript/issues/14729
+          key={JSON.stringify(
+            (child as React.ReactElement<BreadcrumbProps>).props.children
+          )}
+        >
+          {child}
+          {index !== children.length - 1 && <SeparatorIcon />}
+        </React.Fragment>
+      );
+    });
+  } else {
+    childElements.push(children);
+  }
+
+  return (
+    <BreadcrumbContainer>
+      <Link to="/">
+        <HomeIcon className="fa fa-home" />
+      </Link>
+      <SeparatorIcon />
+      {childElements}
+    </BreadcrumbContainer>
+  );
+};
+
+export { Breadcrumb, Breadcrumbs };

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { Breadcrumb, Breadcrumbs } from "./Breadcrumbs";

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,6 +9,7 @@ export interface ThemeInterface {
     divider: string;
     primary: string;
     primaryInverted: string;
+    textMuted: string;
   };
   fonts: {
     families: {
@@ -31,7 +32,8 @@ const theme: ThemeInterface = {
     accent: "#007bff",
     divider: "#ddd",
     primary: "black",
-    primaryInverted: "white"
+    primaryInverted: "white",
+    textMuted: "#555"
   },
   fonts: {
     families: {


### PR DESCRIPTION
The breadcrumbs show the user where they are in relation to the rest of the site. Currently the only page that's deep enough to require breadcrumbs is the blog post detail page.

Closes #8 