### PR TITLE
Close hamburger menu on link click

### DIFF
--- a/src/components/Navigation/Navbar.tsx
+++ b/src/components/Navigation/Navbar.tsx
@@ -135,7 +135,11 @@ class Navbar extends React.Component<IProps, IState> {
             </NavMenuIcon>
           </NavHeader>
           <NavLinks>{children}</NavLinks>
-          {mobileOpen && <NavLinksMobile>{children}</NavLinksMobile>}
+          {mobileOpen && (
+            <NavLinksMobile onClick={this.toggleMenu}>
+              {children}
+            </NavLinksMobile>
+          )}
         </NavContent>
       </NavRoot>
     );


### PR DESCRIPTION
Closes the hamburger menu (on mobile and small web browser screens) when you click on a link.
Closes #14 